### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@ First release deployed to PyPI
 ## [Version 1.0.1]
 There was a bug with the way credentials were stored. This caused the whole credential branch
 for a dialect to be replaced. It has been fixed
+
+## [Version 1.0.2]
+The snowflake dialect has been added

--- a/dsdbmanager/__init__.py
+++ b/dsdbmanager/__init__.py
@@ -1,6 +1,6 @@
 import json
-from .dbobject import DsDbManager, DbMiddleware
 from .configuring import ConfigFilesManager
+from .dbobject import DsDbManager, DbMiddleware
 
 __version__ = '1.0.1'
 configurer = ConfigFilesManager()
@@ -52,6 +52,10 @@ def mssql():
     return DsDbManager('mssql')
 
 
+def snowflake():
+    return DsDbManager('snowflake')
+
+
 def from_engine(engine, schema: str = None):
     """
     Main objective is to use this to create DbMiddleware objects on sqlite engines for quick testing purposes
@@ -76,7 +80,8 @@ def from_engine(engine, schema: str = None):
     >>> df1: pd.DataFrame = db.test()
     >>> df1.equals(df)
     True
-    >>>
+
+    >>> engine.dispose()
 
     """
     return DbMiddleware(engine, False, schema)

--- a/dsdbmanager/__init__.py
+++ b/dsdbmanager/__init__.py
@@ -2,37 +2,37 @@ import json
 from .configuring import ConfigFilesManager
 from .dbobject import DsDbManager, DbMiddleware
 
-__version__ = '1.0.1'
-configurer = ConfigFilesManager()
+__version__ = '1.0.2'
+__configurer__ = ConfigFilesManager()
 
 # first initialize empty files
 # if there are no host files, create an empty json file #
-if not configurer.host_location.exists():
+if not __configurer__.host_location.exists():
     try:
-        configurer.host_location.touch(exist_ok=True)
-        with configurer.host_location.open('w') as f:
+        __configurer__.host_location.touch(exist_ok=True)
+        with __configurer__.host_location.open('w') as f:
             json.dump({}, f)
     except OSError as e:
         raise Exception("Could not write at host file location", e)
 
 # if there are credential files create an empty json file #
-if not configurer.credential_location.exists():
-    configurer.credential_location.touch(exist_ok=True)
+if not __configurer__.credential_location.exists():
+    __configurer__.credential_location.touch(exist_ok=True)
     try:
-        with configurer.credential_location.open('w') as f:
+        with __configurer__.credential_location.open('w') as f:
             json.dump({}, f)
     except OSError as e:
         raise Exception("Could not write at credential file location", e)
 
 # if there are no keys, create one and store it at key location #
-if not configurer.key_location.exists():
-    configurer.key_location.touch(exist_ok=True)
-    configurer.key_location.write_bytes(configurer.generate_key())
+if not __configurer__.key_location.exists():
+    __configurer__.key_location.touch(exist_ok=True)
+    __configurer__.key_location.write_bytes(__configurer__.generate_key())
 
 # functions for users to use
-add_database = configurer.add_new_database_info
-remove_database = configurer.remove_database
-reset_credentials = configurer.reset_credentials
+add_database = __configurer__.add_new_database_info
+remove_database = __configurer__.remove_database
+reset_credentials = __configurer__.reset_credentials
 
 
 # easy access for databases

--- a/dsdbmanager/configuring.py
+++ b/dsdbmanager/configuring.py
@@ -157,7 +157,7 @@ class ConfigFilesManager(object):
                 return None
 
         # additional_infos
-        host = click.prompt("Host/Database Address", type=str)
+        host = click.prompt("Host/Database Address or Snowflake Account", type=str)
         schema = click.prompt("Schema - Enter if none", default='', type=str)
         sid = click.prompt("SID - Enter if none", default='', type=str)
         service_name = click.prompt("Service Name - Enter if none", default='', type=str)

--- a/dsdbmanager/constants.py
+++ b/dsdbmanager/constants.py
@@ -24,7 +24,7 @@ except KeyError:
     KEY_PATH = config_folder / ".configkey"
 
 # database flavors
-FLAVORS_FOR_CONFIG = ('oracle', 'mysql', 'mssql', 'teradata',)
+FLAVORS_FOR_CONFIG = ('oracle', 'mysql', 'mssql', 'teradata', 'snowflake')
 
 CACHE_SIZE = 64
 CHUNK_SIZE = 30000

--- a/dsdbmanager/snowflake_.py
+++ b/dsdbmanager/snowflake_.py
@@ -1,0 +1,52 @@
+import typing
+import sqlalchemy as sa
+from .configuring import ConfigFilesManager
+from .exceptions_ import MissingFlavor, MissingDatabase, MissingPackage
+
+host_type = typing.Dict[str, typing.Dict[str, typing.Dict[str, str]]]
+
+
+class Snowflake:
+    def __init__(self, db_name: str, host_dict: host_type = None):
+        """
+
+        :param db_name: database name
+        :param host_dict: optional database info with host, ports etc
+        """
+        self.db_name = db_name
+        self.host_dict: host_type = ConfigFilesManager().get_hosts() if not host_dict else host_dict
+
+        if not self.host_dict or 'mysql' not in self.host_dict:
+            raise MissingFlavor("No databases available for mysql", None)
+
+        self.host_dict = self.host_dict.get('mysql').get(self.db_name, {})
+
+        if not self.host_dict:
+            raise MissingDatabase(f"{self.db_name} has not been added for mysql", None)
+
+    def create_engine(self, user: str = None, pwd: str = None, **kwargs):
+        """
+
+        :param user: username
+        :param pwd: password
+        :param kwargs: for compatibility/additional sqlalchemy create_engine kwargs or things like role, warehouse etc.
+        :return: sqlalchemy engine
+        """
+        try:
+            from snowflake.sqlalchemy import URL
+        except ImportError as e:
+            raise MissingPackage("You need the snowflake-sqlalchemy package to initiate connection", e)
+
+        host = self.host_dict.get('host')
+
+        url = URL(
+            account=host,
+            user=user,
+            password=pwd,
+            database=self.db_name,
+            **kwargs
+        )
+
+        # TODO - find a way to identify kwrags consumed by URL and pull them out of kwargs and pass the rest below
+
+        return sa.create_engine(url)

--- a/dsdbmanager/snowflake_.py
+++ b/dsdbmanager/snowflake_.py
@@ -16,13 +16,13 @@ class Snowflake:
         self.db_name = db_name
         self.host_dict: host_type = ConfigFilesManager().get_hosts() if not host_dict else host_dict
 
-        if not self.host_dict or 'mysql' not in self.host_dict:
-            raise MissingFlavor("No databases available for mysql", None)
+        if not self.host_dict or 'snowflake' not in self.host_dict:
+            raise MissingFlavor("No databases available for snowflake", None)
 
-        self.host_dict = self.host_dict.get('mysql').get(self.db_name, {})
+        self.host_dict = self.host_dict.get('snowflake').get(self.db_name, {})
 
         if not self.host_dict:
-            raise MissingDatabase(f"{self.db_name} has not been added for mysql", None)
+            raise MissingDatabase(f"{self.db_name} has not been added for snowflake", None)
 
     def create_engine(self, user: str = None, pwd: str = None, **kwargs):
         """

--- a/test/test_connectors.py
+++ b/test/test_connectors.py
@@ -3,6 +3,7 @@ from dsdbmanager.mssql_ import Mssql
 from dsdbmanager.mysql_ import Mysql
 from dsdbmanager.oracle_ import Oracle
 from dsdbmanager.teradata_ import Teradata
+from dsdbmanager.snowflake_ import Snowflake
 from dsdbmanager.exceptions_ import MissingFlavor, MissingDatabase, MissingPackage
 
 
@@ -36,7 +37,14 @@ class TestConnectors(unittest.TestCase):
                     'host': 'somehost',
                     'port': 0000
                 }
-            }
+            },
+            'snowflake': {
+                'database1': {
+                    'name': 'database1',
+                    'host': 'somehost',
+                    'port': 0000
+                }
+            },
         }
 
     @classmethod
@@ -50,12 +58,14 @@ class TestConnectors(unittest.TestCase):
                     'mysql',
                     'mssql',
                     'teradata',
+                    'snowflake'
                 ],
                 [
                     Oracle,
                     Mysql,
                     Mssql,
                     Teradata,
+                    Snowflake
                 ]):
             with self.subTest(flavor=name):
                 # test with host improper host file. should raise MissingFlavor


### PR DESCRIPTION
fixed issue #20 and issue #21 allowing engine kwargs to be passed when calling for a database connection and the `with engine.connect():...` approach is taken over the `engine.execute()` approach discouraged by snowflake docs.