### PR TITLE
adding manifest to include requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,8 @@ There was a bug with the way credentials were stored. This caused the whole cred
 for a dialect to be replaced. It has been fixed
 
 ## [Version 1.0.2]
-The snowflake dialect has been added
+The snowflake dialect has been added 
+
+## [Version 1.0.3]
+1.0.2 build didn't have the wheel files and the requirements.txt was not included
+the manifest file has been added and a wheel file created

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/dsdbmanager/__init__.py
+++ b/dsdbmanager/__init__.py
@@ -2,7 +2,7 @@ import json
 from .configuring import ConfigFilesManager
 from .dbobject import DsDbManager, DbMiddleware
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 __configurer__ = ConfigFilesManager()
 
 # first initialize empty files


### PR DESCRIPTION
Fixes Issue #23 and pip should now be able to get requirements.txt as it is included in package